### PR TITLE
Add iids-portfolio domain (lifecycle taxonomy from AISPEG ADR 0001)

### DIFF
--- a/vocabularies/iids-portfolio/allowed_values.json
+++ b/vocabularies/iids-portfolio/allowed_values.json
@@ -1,0 +1,78 @@
+{
+  "application": "IIDS Portfolio",
+  "description": "Controlled vocabularies for the IIDS Portfolio site (https://aispeg.insight.uidaho.edu) — the institutional inventory of AI interventions across University of Idaho units. Per ADR 0001 (https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0001-product-lifecycle-taxonomy.md), each operational status carries a measurable verification rule that is enforced by lib/portfolio-verification.ts and CI.",
+  "version": "1.0.0",
+  "last_updated": "2026-05-03",
+  "value_groups": [
+    {
+      "Value_Group": "InterventionStatus",
+      "description": "Operational ladder for an intervention — the day-to-day status IIDS tracks. Source of truth: lib/portfolio.ts. Each value's Verification_Rule is enforced by lib/portfolio-verification.ts on every PR.",
+      "values": [
+        { "Code": "idea", "Label": "Idea", "Display_Order": 1, "Description": "Named with a unit-of-interest; not yet committed to build.", "Verification_Rule": "No committed operationalOwner OR no committed iidsSponsor; repoUrl empty or repo has zero commits." },
+        { "Code": "approved", "Label": "Approved", "Display_Order": 2, "Description": "Committed to build with named owner and sponsor; not yet under active development.", "Verification_Rule": "operationalOwners[0] set AND iidsSponsor set AND non-empty description; no liveUrl; repo (if present) has <10 commits OR no commits in last 14 days." },
+        { "Code": "building", "Label": "Building", "Display_Order": 3, "Description": "Active development. Code exists but not yet for real users.", "Verification_Rule": "repoUrl set; lastCommitDate within last 60 days; no liveUrl (or liveUrl flagged liveUrlIsStaging:true); pilotCohort empty." },
+        { "Code": "prototype", "Label": "Prototype", "Display_Order": 4, "Description": "Demo-able but quiet — feature-complete or paused.", "Verification_Rule": "pilotCohort empty; either lastCommitDate older than 30 days OR featureComplete:true." },
+        { "Code": "piloting", "Label": "Piloting", "Display_Order": 5, "Description": "In use by a bounded, named cohort.", "Verification_Rule": "liveUrl set; pilotCohort populated with size > 0 and a bounded scope." },
+        { "Code": "production", "Label": "Production", "Display_Order": 6, "Description": "In real institutional use beyond the pilot cohort.", "Verification_Rule": "Publicly-accessible artifact: liveUrl OR a public repoUrl (isPrivateRepo:false) for repo-as-artifact deliverables (infrastructure, scaffolds, appliances). productionScope and supportContact populated." },
+        { "Code": "maintained", "Label": "Maintained", "Display_Order": 7, "Description": "In production but in maintenance-only mode.", "Verification_Rule": "Inherits production accessibility (liveUrl or public repo); no commits to main in last 90 days; no open feature issues — only bug-, security-, or chore-labeled." },
+        { "Code": "sunsetting", "Label": "Sunsetting", "Display_Order": 8, "Description": "Being wound down with a planned successor.", "Verification_Rule": "sunsetDate (ISO) set; replacedBy populated — successor intervention slug or the literal 'manual-process'." },
+        { "Code": "archived", "Label": "Archived", "Display_Order": 9, "Description": "Stopped. Record kept for institutional memory.", "Verification_Rule": "liveUrl returns 404 / is null / domain dead, or (for repo-as-artifact) repoUrl is archived/deleted; service stopped." },
+        { "Code": "tracked", "Label": "Tracked", "Display_Order": 10, "Description": "Externally-owned intervention IIDS observes but does not build.", "Verification_Rule": "trackingOnly:true; bypasses the operational ladder." }
+      ]
+    },
+    {
+      "Value_Group": "PublicStage",
+      "description": "Stakeholder-facing rollup. Computed deterministically from InterventionStatus by lib/portfolio.ts:computePublicStage. The public surfaces (/portfolio cards primary chip, landing stat strip, /explore tile breakdowns) render this axis; operational status is only shown as a secondary detail on cards.",
+      "values": [
+        { "Code": "exploring", "Label": "Exploring", "Display_Order": 1, "Description": "Thinking about it / committed to build.", "Verification_Rule": "Rolls up from InterventionStatus values: idea, approved." },
+        { "Code": "building", "Label": "Building", "Display_Order": 2, "Description": "Code exists; not yet for real users.", "Verification_Rule": "Rolls up from InterventionStatus values: building, prototype." },
+        { "Code": "live", "Label": "Live", "Display_Order": 3, "Description": "In use today.", "Verification_Rule": "Rolls up from InterventionStatus values: piloting, production, maintained." },
+        { "Code": "retired", "Label": "Retired", "Display_Order": 4, "Description": "Done or winding down.", "Verification_Rule": "Rolls up from InterventionStatus values: sunsetting, archived." },
+        { "Code": "tracked", "Label": "Tracked", "Display_Order": 5, "Description": "Not built by IIDS.", "Verification_Rule": "Rolls up from InterventionStatus value: tracked. Bypasses the operational ladder." }
+      ]
+    },
+    {
+      "Value_Group": "ProductionScope",
+      "description": "Granularity of production reach. Required on InterventionStatus values production and maintained.",
+      "values": [
+        { "Code": "home-unit", "Label": "Home Unit", "Display_Order": 1, "Description": "Accessible to all users in the intervention's home unit." },
+        { "Code": "institution-wide", "Label": "Institution-Wide", "Display_Order": 2, "Description": "Accessible to all UI users." },
+        { "Code": "external", "Label": "External", "Display_Order": 3, "Description": "Deployed beyond UI — partner institutions, open-source distribution, or self-hostable artifact consumed externally." }
+      ]
+    },
+    {
+      "Value_Group": "Visibility",
+      "description": "Public-site disclosure level for an intervention's record.",
+      "values": [
+        { "Code": "Public", "Label": "Public", "Display_Order": 1, "Description": "All fields shown publicly." },
+        { "Code": "Partial", "Label": "Partial", "Display_Order": 2, "Description": "Entry acknowledged on the public site; deployment details (scope, timelines, configuration) embargoed." },
+        { "Code": "Internal-only", "Label": "Internal Only", "Display_Order": 3, "Description": "Not shown on the public site." }
+      ]
+    },
+    {
+      "Value_Group": "AI4RARelationship",
+      "description": "How an intervention relates to the AI4RA partnership (UI + Southern Utah University NSF GRANTED).",
+      "values": [
+        { "Code": "Core", "Label": "Core", "Display_Order": 1, "Description": "AI4RA OSS project with a UI deployment — dual-destiny." },
+        { "Code": "Adjacent", "Label": "Adjacent", "Display_Order": 2, "Description": "Related to AI4RA but not part of the partnership proper." },
+        { "Code": "Reference", "Label": "Reference", "Display_Order": 3, "Description": "UI deployment consumes an AI4RA spec or tool." },
+        { "Code": "UI-parallel", "Label": "UI-Parallel", "Display_Order": 4, "Description": "UI work running alongside an AI4RA initiative." },
+        { "Code": "None", "Label": "None", "Display_Order": 5, "Description": "No AI4RA relationship." }
+      ]
+    },
+    {
+      "Value_Group": "WorkCategory",
+      "description": "By-problem axis for browsing the portfolio. Audience-facing labels written in a Dean's vocabulary (not technical jargon). Source of truth: lib/work-categories.ts. One intervention can sit in 2-3 categories.",
+      "values": [
+        { "Code": "documents", "Label": "Working with documents", "Display_Order": 1, "Description": "Extracting, reviewing, or finding answers in documents — contracts, reports, RFPs, audit findings." },
+        { "Code": "process", "Label": "Streamlining a process", "Display_Order": 2, "Description": "Mapping, automating, or removing bottlenecks from operational workflows." },
+        { "Code": "coordination", "Label": "Coordinating people and time", "Display_Order": 3, "Description": "Calendars, schedules, daily registers, multi-party logistics." },
+        { "Code": "reconciliation", "Label": "Reconciling accounts and records", "Display_Order": 4, "Description": "Financial reviews, audit cycles, matching transactions to source data." },
+        { "Code": "executive-analytics", "Label": "Executive visibility", "Display_Order": 5, "Description": "Dashboards, strategic alignment, portfolio-level rollups for leadership." },
+        { "Code": "research-admin", "Label": "Research administration", "Display_Order": 6, "Description": "Proposal lifecycle, awards, sponsor compliance, ORED operations." },
+        { "Code": "knowledge-retrieval", "Label": "Searching institutional knowledge", "Display_Order": 7, "Description": "Retrieval and Q&A over policies, history, decisions — RAG-style." },
+        { "Code": "ai-infrastructure", "Label": "AI infrastructure", "Display_Order": 8, "Description": "LLM gateways, GPU stacks, agent platforms — the plumbing other interventions run on, not a problem on its own." }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Registers the IIDS Portfolio site's controlled vocabularies under a new \`iids-portfolio\` domain. This is step 5 of the lifecycle-taxonomy rollout in [ui-insight/AISPEG](https://github.com/ui-insight/AISPEG); the rules being recorded here are spec'd in [ADR 0001](https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0001-product-lifecycle-taxonomy.md) and enforced in code by [\`lib/portfolio-verification.ts\`](https://github.com/ui-insight/AISPEG/blob/main/lib/portfolio-verification.ts).

Once this is merged, AISPEG bumps its \`vendor/data-governance\` submodule pointer and the drift workflow starts policing these vocabularies alongside the existing audit / openera / processmapping / communications / research-admin / shared domains.

## What lands

One new file: \`vocabularies/iids-portfolio/allowed_values.json\` with six vocabulary groups:

| Group | Cardinality | Verification_Rule field |
|---|---|---|
| \`InterventionStatus\` | 10 | Yes — per-status measurable rule from ADR table |
| \`PublicStage\` | 5 | Yes — describes the rollup mapping |
| \`ProductionScope\` | 3 | No — granularity tag, not a status |
| \`Visibility\` | 3 | No |
| \`AI4RARelationship\` | 5 | No |
| \`WorkCategory\` | 8 | No |

## Schema extension: \`Verification_Rule\`

This adds a per-value \`Verification_Rule\` string field, currently scoped to the \`iids-portfolio\` domain (only \`InterventionStatus\` and \`PublicStage\` carry meaningful values). The field is **additive** — other domains' \`allowed_values.json\` don't include it, and consumers (like the AISPEG catalog builder) that don't yet read it simply ignore it. Adopting it for the existing four domains can happen later if/when those vocabularies grow verification rules of their own.

## Test plan
- [x] JSON validates (six \`value_groups\`, all required fields present)
- [ ] Drift workflow doesn't false-positive on the new domain
- [ ] AISPEG-side regeneration (\`npm run build:governance\`) emits the new vocabularies into \`lib/governance/vocabularies.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)