### PR TITLE
Rename InterventionStatus → ProjectStatus + retire "intervention" prose

### DIFF
--- a/vocabularies/iids-portfolio/allowed_values.json
+++ b/vocabularies/iids-portfolio/allowed_values.json
@@ -1,12 +1,12 @@
 {
   "application": "IIDS Portfolio",
-  "description": "Controlled vocabularies for the IIDS Portfolio site (https://aispeg.insight.uidaho.edu) — the institutional inventory of AI interventions across University of Idaho units. Per ADR 0001 (https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0001-product-lifecycle-taxonomy.md), each operational status carries a measurable verification rule that is enforced by lib/portfolio-verification.ts and CI.",
-  "version": "1.0.0",
+  "description": "Controlled vocabularies for the IIDS Portfolio site (https://aispeg.insight.uidaho.edu) — the institutional inventory of AI projects across University of Idaho units. Per ADR 0001 (https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0001-product-lifecycle-taxonomy.md), each operational status carries a measurable verification rule that is enforced by lib/portfolio-verification.ts and CI.",
+  "version": "2.0.0",
   "last_updated": "2026-05-03",
   "value_groups": [
     {
-      "Value_Group": "InterventionStatus",
-      "description": "Operational ladder for an intervention — the day-to-day status IIDS tracks. Source of truth: lib/portfolio.ts. Each value's Verification_Rule is enforced by lib/portfolio-verification.ts on every PR.",
+      "Value_Group": "ProjectStatus",
+      "description": "Operational ladder for a project — the day-to-day status IIDS tracks. Source of truth: lib/portfolio.ts. Each value's Verification_Rule is enforced by lib/portfolio-verification.ts on every PR.",
       "values": [
         { "Code": "idea", "Label": "Idea", "Display_Order": 1, "Description": "Named with a unit-of-interest; not yet committed to build.", "Verification_Rule": "No committed operationalOwner OR no committed iidsSponsor; repoUrl empty or repo has zero commits." },
         { "Code": "approved", "Label": "Approved", "Display_Order": 2, "Description": "Committed to build with named owner and sponsor; not yet under active development.", "Verification_Rule": "operationalOwners[0] set AND iidsSponsor set AND non-empty description; no liveUrl; repo (if present) has <10 commits OR no commits in last 14 days." },
@@ -15,34 +15,34 @@
         { "Code": "piloting", "Label": "Piloting", "Display_Order": 5, "Description": "In use by a bounded, named cohort.", "Verification_Rule": "liveUrl set; pilotCohort populated with size > 0 and a bounded scope." },
         { "Code": "production", "Label": "Production", "Display_Order": 6, "Description": "In real institutional use beyond the pilot cohort.", "Verification_Rule": "Publicly-accessible artifact: liveUrl OR a public repoUrl (isPrivateRepo:false) for repo-as-artifact deliverables (infrastructure, scaffolds, appliances). productionScope and supportContact populated." },
         { "Code": "maintained", "Label": "Maintained", "Display_Order": 7, "Description": "In production but in maintenance-only mode.", "Verification_Rule": "Inherits production accessibility (liveUrl or public repo); no commits to main in last 90 days; no open feature issues — only bug-, security-, or chore-labeled." },
-        { "Code": "sunsetting", "Label": "Sunsetting", "Display_Order": 8, "Description": "Being wound down with a planned successor.", "Verification_Rule": "sunsetDate (ISO) set; replacedBy populated — successor intervention slug or the literal 'manual-process'." },
+        { "Code": "sunsetting", "Label": "Sunsetting", "Display_Order": 8, "Description": "Being wound down with a planned successor.", "Verification_Rule": "sunsetDate (ISO) set; replacedBy populated — successor project slug or the literal 'manual-process'." },
         { "Code": "archived", "Label": "Archived", "Display_Order": 9, "Description": "Stopped. Record kept for institutional memory.", "Verification_Rule": "liveUrl returns 404 / is null / domain dead, or (for repo-as-artifact) repoUrl is archived/deleted; service stopped." },
-        { "Code": "tracked", "Label": "Tracked", "Display_Order": 10, "Description": "Externally-owned intervention IIDS observes but does not build.", "Verification_Rule": "trackingOnly:true; bypasses the operational ladder." }
+        { "Code": "tracked", "Label": "Tracked", "Display_Order": 10, "Description": "Externally-owned project IIDS observes but does not build.", "Verification_Rule": "trackingOnly:true; bypasses the operational ladder." }
       ]
     },
     {
       "Value_Group": "PublicStage",
-      "description": "Stakeholder-facing rollup. Computed deterministically from InterventionStatus by lib/portfolio.ts:computePublicStage. The public surfaces (/portfolio cards primary chip, landing stat strip, /explore tile breakdowns) render this axis; operational status is only shown as a secondary detail on cards.",
+      "description": "Stakeholder-facing rollup. Computed deterministically from ProjectStatus by lib/portfolio.ts:computePublicStage. The public surfaces (/portfolio cards primary chip, landing stat strip, /explore tile breakdowns) render this axis; operational status is only shown as a secondary detail on cards.",
       "values": [
-        { "Code": "exploring", "Label": "Exploring", "Display_Order": 1, "Description": "Thinking about it / committed to build.", "Verification_Rule": "Rolls up from InterventionStatus values: idea, approved." },
-        { "Code": "building", "Label": "Building", "Display_Order": 2, "Description": "Code exists; not yet for real users.", "Verification_Rule": "Rolls up from InterventionStatus values: building, prototype." },
-        { "Code": "live", "Label": "Live", "Display_Order": 3, "Description": "In use today.", "Verification_Rule": "Rolls up from InterventionStatus values: piloting, production, maintained." },
-        { "Code": "retired", "Label": "Retired", "Display_Order": 4, "Description": "Done or winding down.", "Verification_Rule": "Rolls up from InterventionStatus values: sunsetting, archived." },
-        { "Code": "tracked", "Label": "Tracked", "Display_Order": 5, "Description": "Not built by IIDS.", "Verification_Rule": "Rolls up from InterventionStatus value: tracked. Bypasses the operational ladder." }
+        { "Code": "exploring", "Label": "Exploring", "Display_Order": 1, "Description": "Thinking about it / committed to build.", "Verification_Rule": "Rolls up from ProjectStatus values: idea, approved." },
+        { "Code": "building", "Label": "Building", "Display_Order": 2, "Description": "Code exists; not yet for real users.", "Verification_Rule": "Rolls up from ProjectStatus values: building, prototype." },
+        { "Code": "live", "Label": "Live", "Display_Order": 3, "Description": "In use today.", "Verification_Rule": "Rolls up from ProjectStatus values: piloting, production, maintained." },
+        { "Code": "retired", "Label": "Retired", "Display_Order": 4, "Description": "Done or winding down.", "Verification_Rule": "Rolls up from ProjectStatus values: sunsetting, archived." },
+        { "Code": "tracked", "Label": "Tracked", "Display_Order": 5, "Description": "Not built by IIDS.", "Verification_Rule": "Rolls up from ProjectStatus value: tracked. Bypasses the operational ladder." }
       ]
     },
     {
       "Value_Group": "ProductionScope",
-      "description": "Granularity of production reach. Required on InterventionStatus values production and maintained.",
+      "description": "Granularity of production reach. Required on ProjectStatus values production and maintained.",
       "values": [
-        { "Code": "home-unit", "Label": "Home Unit", "Display_Order": 1, "Description": "Accessible to all users in the intervention's home unit." },
+        { "Code": "home-unit", "Label": "Home Unit", "Display_Order": 1, "Description": "Accessible to all users in the project's home unit." },
         { "Code": "institution-wide", "Label": "Institution-Wide", "Display_Order": 2, "Description": "Accessible to all UI users." },
         { "Code": "external", "Label": "External", "Display_Order": 3, "Description": "Deployed beyond UI — partner institutions, open-source distribution, or self-hostable artifact consumed externally." }
       ]
     },
     {
       "Value_Group": "Visibility",
-      "description": "Public-site disclosure level for an intervention's record.",
+      "description": "Public-site disclosure level for a project's record.",
       "values": [
         { "Code": "Public", "Label": "Public", "Display_Order": 1, "Description": "All fields shown publicly." },
         { "Code": "Partial", "Label": "Partial", "Display_Order": 2, "Description": "Entry acknowledged on the public site; deployment details (scope, timelines, configuration) embargoed." },
@@ -51,7 +51,7 @@
     },
     {
       "Value_Group": "AI4RARelationship",
-      "description": "How an intervention relates to the AI4RA partnership (UI + Southern Utah University NSF GRANTED).",
+      "description": "How a project relates to the AI4RA partnership (UI + Southern Utah University NSF GRANTED).",
       "values": [
         { "Code": "Core", "Label": "Core", "Display_Order": 1, "Description": "AI4RA OSS project with a UI deployment — dual-destiny." },
         { "Code": "Adjacent", "Label": "Adjacent", "Display_Order": 2, "Description": "Related to AI4RA but not part of the partnership proper." },
@@ -62,7 +62,7 @@
     },
     {
       "Value_Group": "WorkCategory",
-      "description": "By-problem axis for browsing the portfolio. Audience-facing labels written in a Dean's vocabulary (not technical jargon). Source of truth: lib/work-categories.ts. One intervention can sit in 2-3 categories.",
+      "description": "By-problem axis for browsing the portfolio. Audience-facing labels written in a Dean's vocabulary (not technical jargon). Source of truth: lib/work-categories.ts. One project can sit in 2-3 categories.",
       "values": [
         { "Code": "documents", "Label": "Working with documents", "Display_Order": 1, "Description": "Extracting, reviewing, or finding answers in documents — contracts, reports, RFPs, audit findings." },
         { "Code": "process", "Label": "Streamlining a process", "Display_Order": 2, "Description": "Mapping, automating, or removing bottlenecks from operational workflows." },
@@ -71,7 +71,7 @@
         { "Code": "executive-analytics", "Label": "Executive visibility", "Display_Order": 5, "Description": "Dashboards, strategic alignment, portfolio-level rollups for leadership." },
         { "Code": "research-admin", "Label": "Research administration", "Display_Order": 6, "Description": "Proposal lifecycle, awards, sponsor compliance, ORED operations." },
         { "Code": "knowledge-retrieval", "Label": "Searching institutional knowledge", "Display_Order": 7, "Description": "Retrieval and Q&A over policies, history, decisions — RAG-style." },
-        { "Code": "ai-infrastructure", "Label": "AI infrastructure", "Display_Order": 8, "Description": "LLM gateways, GPU stacks, agent platforms — the plumbing other interventions run on, not a problem on its own." }
+        { "Code": "ai-infrastructure", "Label": "AI infrastructure", "Display_Order": 8, "Description": "LLM gateways, GPU stacks, agent platforms — the plumbing other projects run on, not a problem on its own." }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Rename `Value_Group: "InterventionStatus"` → `"ProjectStatus"` in `vocabularies/iids-portfolio/allowed_values.json`. Five internal references in `PublicStage` and `ProductionScope` verification rules updated to match.
- Replace "intervention" with "project" in 11 prose descriptions across the IIDS Portfolio domain catalog.
- Bump `version` 1.0.0 → 2.0.0 (renaming a `Value_Group` is breaking for any string-matching consumer).

## Why

Stakeholder feedback on the consuming site (May 2026): "intervention" reads as harsh and clinical for an institutional audience. "Project" is the term the audience already uses, matches the language on `/builder-guide` ("Submit a Project") on the consuming site, and lets the IIDS Portfolio voice match the brand brief's *quietly-confident* register.

This is the upstream half of a coordinated rename. See [`ui-insight/AISPEG#189`](https://github.com/ui-insight/AISPEG/issues/189) for the epic and [`ui-insight/AISPEG#190`](https://github.com/ui-insight/AISPEG/issues/190) for this slice's tracking issue.

## Scope

Single file: `vocabularies/iids-portfolio/allowed_values.json`. 18 line changes (18+/18−). Only string substitutions; no structural changes to the JSON schema.

Verified:

- `python3 -c "import json; json.load(...)"` — JSON valid.
- `grep -ri "intervention" .` — no remaining occurrences anywhere in the repo (other domain catalogs, scripts, README, and `docs/` carry no references).
- `scripts/check_governance_drift.py` does not string-match `InterventionStatus`, so the upstream drift check is unaffected by the rename.

## Sequencing

Once this lands, [`ui-insight/AISPEG#191`](https://github.com/ui-insight/AISPEG/issues/191) follows immediately to bump the AISPEG submodule pointer and regenerate the local typed catalogs. The drift CI on AISPEG will be red on unrelated PRs in the interim — closing that gap is the rename epic's known sequencing risk.

## Test plan

- [ ] Upstream `Governance Drift` CI green on this PR.
- [ ] After merge, AISPEG submodule bump (#191) regenerates `lib/governance/{catalog,vocabularies}.ts` cleanly with no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)