### PR TITLE
Refresh ProcessMapping drift canary: 10/78 → 13/89

### DIFF
--- a/scripts/check_governance_drift.py
+++ b/scripts/check_governance_drift.py
@@ -324,7 +324,7 @@ def run_remote_checks(checks: CheckRunner) -> None:
     )
     pm_remote_values = len(processmapping_allowed["AllowedValues"])
     checks.require(
-        pm_remote_groups == 10 and pm_remote_values == 78,
+        pm_remote_groups == 13 and pm_remote_values == 89,
         "ProcessMapping remote controlled-value counts match local governance registry",
     )
 


### PR DESCRIPTION
The live [`ui-insight/ProcessMapping`](https://github.com/ui-insight/ProcessMapping) `data/allowed_values.json` has grown to **13 controlled-value groups / 89 values** (new groups: `CoverageAssertionMode`, `CoverageDepth`, `CoverageStatus`, `RedactionStatus`, …), but `scripts/check_governance_drift.py` still asserted the old `10 / 78`. That made the drift canary fail on every PR that runs the drift workflow — a latent failure, since no recent PR had touched `vendor/data-governance` downstream.

Updates the expected counts to match the live registry. Pre-existing drift, unrelated to the concurrent `paused`-status work.